### PR TITLE
Add video width and height to muxer metadata

### DIFF
--- a/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RTMPMuxer.java
+++ b/rtmp-client/src/main/java/net/butterflytv/rtmp_client/RTMPMuxer.java
@@ -9,7 +9,7 @@ public class RTMPMuxer {
         System.loadLibrary("rtmp-jni");
     }
 
-    public native int open(String url);
+    public native int open(String url, int video_width, int video_height);
 
     /**
      * write h264 nal units

--- a/rtmp-client/src/main/jni/flvmuxer/xiecc_rtmp.c
+++ b/rtmp-client/src/main/jni/flvmuxer/xiecc_rtmp.c
@@ -142,7 +142,7 @@ static uint8_t gen_audio_tag_header()
     val = 0xA0 | (soundRate << 2) | 0x02 | soundType;
     return val;
 }
-int rtmp_open_for_write(const char *url) {
+int rtmp_open_for_write(const char *url, uint32_t video_width, uint32_t video_height) {
     rtmp = RTMP_Alloc();
     if (rtmp == NULL) {
         return -1;
@@ -184,7 +184,9 @@ int rtmp_open_for_write(const char *url) {
         output = AMF_EncodeString(output, outend, &av_onMetaData);
         *output++ = AMF_ECMA_ARRAY;
 
-        output = AMF_EncodeInt32(output, outend, 3);
+        output = AMF_EncodeInt32(output, outend, 5);
+        output = AMF_EncodeNamedNumber(output, outend, &av_width, video_width);
+        output = AMF_EncodeNamedNumber(output, outend, &av_height, video_height);
         output = AMF_EncodeNamedNumber(output, outend, &av_duration, 0.0);
         output = AMF_EncodeNamedNumber(output, outend, &av_videocodecid, 7);
         output = AMF_EncodeNamedNumber(output, outend, &av_audiocodecid, 10);

--- a/rtmp-client/src/main/jni/flvmuxer/xiecc_rtmp.h
+++ b/rtmp-client/src/main/jni/flvmuxer/xiecc_rtmp.h
@@ -16,7 +16,7 @@ extern "C"{
 #define RTMP_STREAM_PROPERTY_RECORD      0x00000004
 
 
-int rtmp_open_for_write(const char *url);
+int rtmp_open_for_write(const char *url, uint32_t video_width, uint32_t video_height);
 
 int rtmp_close();
 

--- a/rtmp-client/src/main/jni/rtmpmuxer.c
+++ b/rtmp-client/src/main/jni/rtmpmuxer.c
@@ -7,10 +7,10 @@
  * if it returns bigger than 0 it is successfull
  */
 JNIEXPORT jint JNICALL
-Java_net_butterflytv_rtmp_1client_RTMPMuxer_open(JNIEnv *env, jobject instance, jstring url_) {
+Java_net_butterflytv_rtmp_1client_RTMPMuxer_open(JNIEnv *env, jobject instance, jstring url_, jint video_width, jint video_height) {
     const char *url = (*env)->GetStringUTFChars(env, url_, 0);
 
-    int result = rtmp_open_for_write(url);
+    int result = rtmp_open_for_write(url, video_width, video_height);
 
     (*env)->ReleaseStringUTFChars(env, url_, url);
     return result;


### PR DESCRIPTION
Someone may want to read video width and height from muxer metadata directly.